### PR TITLE
A bunch of fixes

### DIFF
--- a/app/views/account/_login.html.erb
+++ b/app/views/account/_login.html.erb
@@ -19,7 +19,7 @@
              ENV['RECAPTCHA_PRIVATE_KEY'] = Setting.plugin_recaptcha['recaptcha_private_key']
              if ENV['RECAPTCHA_PRIVATE_KEY'].presence and params[:controller] != 'account'
           %>
-              <%= recaptcha_tags :public_key => ENV['RECAPTCHA_PUBLIC_KEY']%>
+              <%= recaptcha_tags :hl=>current_language, :site_key => ENV['RECAPTCHA_PUBLIC_KEY']%>
           <% end %>
         </td>
       </tr>

--- a/app/views/account/login.html.erb
+++ b/app/views/account/login.html.erb
@@ -18,7 +18,7 @@
          ENV['RECAPTCHA_PRIVATE_KEY'] = Setting.plugin_recaptcha['recaptcha_private_key']
          if ENV['RECAPTCHA_PRIVATE_KEY'].presence
       %>
-          <%= recaptcha_tags :public_key => ENV['RECAPTCHA_PUBLIC_KEY'] %>
+          <%= recaptcha_tags :hl=>current_language, :site_key => ENV['RECAPTCHA_PUBLIC_KEY'] %>
       <% end %>
     </td>
   </tr>

--- a/app/views/account/register.html.erb
+++ b/app/views/account/register.html.erb
@@ -31,7 +31,7 @@
      ENV['RECAPTCHA_PRIVATE_KEY'] = Setting.plugin_recaptcha['recaptcha_private_key']
      if ENV['RECAPTCHA_PRIVATE_KEY'].presence
   %>
-      <%= recaptcha_tags :public_key => ENV['RECAPTCHA_PUBLIC_KEY'] %>
+      <%= recaptcha_tags :hl=>current_language, :site_key => ENV['RECAPTCHA_PUBLIC_KEY'] %>
   <% end %>
 </div>
 

--- a/init.rb
+++ b/init.rb
@@ -1,4 +1,4 @@
-require 'account_controller_patch'
+require 'account_controller_recaptcha_patch'
 
 Redmine::Plugin.register :recaptcha do
   name 'Recaptcha plugin'

--- a/lib/account_controller_recaptcha_patch.rb
+++ b/lib/account_controller_recaptcha_patch.rb
@@ -8,7 +8,7 @@ module AccountControllerRecaptchaPatch
             redirect_back_or_default home_url, :referer => true
           end
         else
-          if !Setting.plugin_recaptcha['recaptcha_private_key'].presence or verify_recaptcha(:model => @user, :private_key => Setting.plugin_recaptcha['recaptcha_private_key'])
+          if verify_recaptcha(:model => @user, :secret_key => Setting.plugin_recaptcha['recaptcha_private_key'])
             authenticate_user
           end
         end
@@ -42,7 +42,7 @@ module AccountControllerRecaptchaPatch
             unless user_params[:identity_url].present? && user_params[:password].blank? && user_params[:password_confirmation].blank?
               @user.password, @user.password_confirmation = user_params[:password], user_params[:password_confirmation]
             end
-            if !Setting.plugin_recaptcha['recaptcha_private_key'].presence  or verify_recaptcha(:model => @user, :private_key => Setting.plugin_recaptcha['recaptcha_private_key'])
+            if verify_recaptcha(:model => @user, :secret_key => Setting.plugin_recaptcha['recaptcha_private_key'])
               case Setting.self_registration
                 when '1'
                   register_by_email_activation(@user)


### PR DESCRIPTION
Fix: renamed account_controller_recaptcha_patch.rb to prevent conflicts with

another account controller plugins.
Fix: upgrading to recaptcha v2 / compatible with recaptcha 4.0.0 gem
Nowadays recaptcha uses fields: site_key and secret_key instead of
public_key and private_key. That prevent before Error:
ActionView::Template::Error (No site key specified.)
Fix: Recaptcha uses language from redmine by h1 settings